### PR TITLE
remove SimpleLogin domain

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -3085,7 +3085,6 @@
     "ulforex.com",
     "kvhrw.com",
     "eledeen.org",
-    "aleeas.com",
     "esmoud.com",
     "keyido.com",
     "advew.com",

--- a/domains.txt
+++ b/domains.txt
@@ -3084,7 +3084,6 @@ otodir.com
 ulforex.com
 kvhrw.com
 eledeen.org
-aleeas.com
 esmoud.com
 keyido.com
 advew.com


### PR DESCRIPTION
SimpleLogin is an open source email alias service and its aliases are not considered as disposable email address in that they are permanent.

More info on SimpleLogin on its website at https://simplelogin.io/ and Github repo at https://github.com/simple-login/app

