### PR TITLE
Remove duplicate "fou.ink"

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -3177,7 +3177,6 @@ cpc.cx
 1xp.fr
 tty.io
 e3b.org
-fou.ink
 thug.pw
 ves.ink
 new.ovh


### PR DESCRIPTION
The entry "fou.ink" occurs twice - one can be removed.