### PR TITLE
Add quizino.pl

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -3601,3 +3601,4 @@ codverts.com
 tempmail.gg
 toaik.com
 daxiake.com
+quizino.pl


### PR DESCRIPTION
Add quizino.pl - a domain used by a temporary email service: https://spambox.pl/