### PR TITLE
Add rapidletter.net

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -3602,3 +3602,4 @@ tempmail.gg
 toaik.com
 daxiake.com
 quizino.pl
+rapidletter.net


### PR DESCRIPTION
Add rapidletter.net – temporary e-mail domain from https://adguard.com/pl/adguard-temp-mail/overview.html