### PR TITLE
Remove Fastmail-operated domain incorrectly listed as disposable

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -3065,7 +3065,6 @@ gotti.otherinbox.com
 mail.mezimages.net
 mail.zp.ua
 neverbox.com
-nospammail.net
 recursor.net
 emergentvillage.org
 runmail.club


### PR DESCRIPTION
Removes nospammail.net from domains.txt. This is a privacy/alias domain 
operated by Fastmail (a legitimate paid email provider), not a throwaway 
address.

Note: editing domains.txt only — domains.json is generated via 
tools/create_json.php so no direct edit needed there.

Relates to: https://github.com/unkn0w/disposable-email-domain-list/issues/20

**Domain verification (verifymail.io):**
- [x] [nospammail.net](https://verifymail.io/domain/nospammail.net) — Disposable: No, Provider: fastmail.com